### PR TITLE
Fixed issues with XMaterial not working correctly on modern versions

### DIFF
--- a/core/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/core/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -1834,11 +1834,13 @@ public enum XMaterial implements XBase<XMaterial, Material> {
         this.data = (byte) data;
         this.legacy = legacy;
 
-        Material mat = null;
-        if ((!Data.ISFLAT && this.isDuplicated()) || (mat = Data.getExactMaterial(this.name())) == null) {
-            for (int i = legacy.length - 1; i >= 0; i--) { // Backwards checkup
-                mat = Data.getExactMaterial(legacy[i]);
-                if (mat != null) break;
+        Material mat = Data.getExactMaterial(name());
+        if (mat == null) {
+            if ((!Data.ISFLAT && this.isDuplicated()) || (mat = Data.getExactMaterial(this.name())) == null) {
+                for (int i = legacy.length - 1; i >= 0; i--) { // Backwards checkup
+                    mat = Data.getExactMaterial(legacy[i]);
+                    if (mat != null) break;
+                }
             }
         }
 


### PR DESCRIPTION
Basically, I had the issue that, for example, stuff like RED_DYE would be displayed as INC_SACK on newer versions, so I just made a small change to see if the newer material exists; then it should be used instead.
I also tired this in game and it fixed my issue.